### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 cleanup.py --path sampleData"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ optional arguments:
   --file FILE  Clean up a specified file (default: all files in current
                directory)
   --path PATH  Target specified directory (default: current directory)
+
+
+
+[![Run on Repl.it](https://repl.it/badge/github/TonyHsieh/cleanup_data)](https://repl.it/github/TonyHsieh/cleanup_data)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Tony_Hsieh/cleanupdata).